### PR TITLE
Use specific log file for routine log messages

### DIFF
--- a/CRM/Googlegroup/Form/Sync.php
+++ b/CRM/Googlegroup/Form/Sync.php
@@ -210,7 +210,7 @@ class CRM_Googlegroup_Form_Sync extends CRM_Core_Form {
       return CRM_Queue_Task::TASK_SUCCESS;
     }
     // Log the batch unsubscribe details
-    CRM_Core_Error::debug_var( 'Google Group batchUnsubscribe $batch= ', $batch);
+    CRM_Core_Error::debug_var( 'Google Group batchUnsubscribe $batch= ', $batch, true, true, "googlegroup");
     $results = civicrm_api('Googlegroup', 'deletemember', array('version' => 3, 'group_id' => $groupID, 'member' => $batch));
     // Finally we can delete the emails that we just processed from the mailchimp temp table.
     CRM_Core_DAO::executeQuery(

--- a/CRM/Googlegroup/Form/Sync.php
+++ b/CRM/Googlegroup/Form/Sync.php
@@ -251,7 +251,7 @@ class CRM_Googlegroup_Form_Sync extends CRM_Core_Form {
     $results = civicrm_api('Googlegroup', 'subscribe', array('version' => 3, 'group_id' => $groupID, 'emails' => $batch, 'role' => 'MEMBER'));
     
     // Log the batch subscribe details
-    CRM_Core_Error::debug_var( 'Google Group batchSubscribe $batch= ', $batch);
+    CRM_Core_Error::debug_var( 'Google Group batchSubscribe $batch= ', $batch, true, true, "googlegroup");
     
     static::updatePushStats($stats);
     // Finally, finish up by removing the two temporary tables


### PR DESCRIPTION
When used with a regular cron job the routine sync messages can crowd out main log, so would be good to use a separate prefixed log file